### PR TITLE
[Hotfix] check_aps

### DIFF
--- a/Graph/LowLink.cpp
+++ b/Graph/LowLink.cpp
@@ -33,11 +33,11 @@ struct LowLink{
         ++count;
         dfs(i,now,k);
         low[now] = min(low[now],low[i]);
-        if (par != 1 && ord[now] <= low[i]) check_aps[now] = true;
+        if (par != -1 && ord[now] <= low[i]) check_aps[now] = true;
         if (ord[now] < low[i]) bridges.emplace_back(min(now,i),max(now,i));
       }
     }
-    if (par == 1 && count >= 2) check_aps[now] = true;
+    if (par == -1 && count >= 2) check_aps[now] = true;
     if (check_aps[now]) aps.push_back(now); 
   }
  

--- a/Graph/TwoEdgeConnectedComponents.cpp
+++ b/Graph/TwoEdgeConnectedComponents.cpp
@@ -64,10 +64,10 @@ struct TwoEdgeConnectedComponents{
         ++count;
         dfs(i,now,k);
         low[now] = min(low[now],low[i]);
-        if (par != 1 && ord[now] <= low[i]) check_aps[now] = true;
+        if (par != -1 && ord[now] <= low[i]) check_aps[now] = true;
       }
     }
-    if (par == 1 && count >= 2) check_aps[now] = true;
+    if (par == -1 && count >= 2) check_aps[now] = true;
   }
  
   bool is_aps(int x){


### PR DESCRIPTION
LowLink.cpp
TwoEdgeConnectedComponents.cpp
のcheck_ansに代入する部分で致命的なバグがあったので修正。